### PR TITLE
Height fix for images

### DIFF
--- a/packages/ezwt_extension/ezextension/ezwt/design/standard/stylesheets/websitetoolbar.css
+++ b/packages/ezwt_extension/ezextension/ezwt/design/standard/stylesheets/websitetoolbar.css
@@ -149,6 +149,7 @@ div#ezwt input.ezwt-input-image, div#ezwt div.ezwt-actiongroup a img
     margin: 1px 0 0 0;
     border: 1px solid #fff;
     padding: 2px;
+    height: auto;
 }
 
 div#ezwt input.ezwt-input-image:hover, div#ezwt div.ezwt-actiongroup a:hover img


### PR DESCRIPTION
When specifying css like below, the image proportions look horrible in the toolbar itself.

``` css
input { height: 1.2em; }
```

This simple fix sets the responsibility to the input element back to the toolbar itself. It can be debated if it's wanted to use **div#ezwt input** instead, but as all input is not using images it might cause unintentional display problems other places.
