### PR TITLE
removed duplicated ContentObjectLanguageCode input when object can be ed...

### DIFF
--- a/packages/ezwt_extension/ezextension/ezwt/design/standard/templates/parts/website_toolbar.tpl
+++ b/packages/ezwt_extension/ezextension/ezwt/design/standard/templates/parts/website_toolbar.tpl
@@ -120,7 +120,10 @@
   {else}
     {set $content_object_language_code = ''}
   {/if}
-  <input type="hidden" name="ContentObjectLanguageCode" value="{$content_object_language_code}" />
+
+  {if $content_object.can_edit|not()}
+    <input type="hidden" name="ContentObjectLanguageCode" value="{$content_object_language_code}" />
+  {/if}
 
 {if ezini( 'SiteSettings', 'AdditionalLoginFormActionURL' )}{* has_access_to_limitation('user', 'login', hash('SiteAccess', '<!-- SiteAccessName -->')) *}
     <a href="{ezini( 'SiteSettings', 'AdditionalLoginFormActionURL' )|explode('user/login')[0]}{$current_node.url_alias}" target="_blank" title="{'Go to admin interface.'|i18n( 'design/standard/parts/website_toolbar' )}"><img src={"websitetoolbar/ezwt-icon-admin.png"|ezimage} alt="{'Go to admin interface.'|i18n( 'design/standard/parts/website_toolbar' )}" /></a>


### PR DESCRIPTION
...ited

When object can be edited, the toolbar was generating duplicated ContentObjectLanguageCode input which was breaking the editing in the language set in INI.
