### PR TITLE
Fetch user instead of using $current_user

### DIFF
--- a/packages/ezwt_extension/ezextension/ezwt/design/standard/templates/parts/website_toolbar.tpl
+++ b/packages/ezwt_extension/ezextension/ezwt/design/standard/templates/parts/website_toolbar.tpl
@@ -10,7 +10,7 @@
      $odf_import_access = fetch( 'user', 'has_access_to', hash( 'module', 'ezodf', 'function', 'import' ) )
      $odf_export_access = fetch( 'user', 'has_access_to', hash( 'module', 'ezodf', 'function', 'export' ) )
      $content_object_language_code = ''
-     $policies = fetch( 'user', 'user_role', hash( 'user_id', $current_user.contentobject_id ) )
+     $policies = fetch( 'user', 'user_role', hash( 'user_id', fetch( 'user', 'current_user' ).contentobject_id ) )
      $available_for_current_class = false()
      $custom_templates = ezini( 'CustomTemplateSettings', 'CustomTemplateList', 'websitetoolbar.ini' )
      $include_in_view = ezini( 'CustomTemplateSettings', 'IncludeInView', 'websitetoolbar.ini' )


### PR DESCRIPTION
Fixes regression in [EZP-22193](http://jira.ez.no/browse/EZP-22193), where `$current_user` isn't set in a legacy callback.

in any case, it isn't good practice to rely on a variable that may or may not be set.
