### PR TITLE
EZP-23478: redirection after publish form fields

### DIFF
--- a/packages/ezwt_extension/ezextension/ezwt/design/standard/templates/parts/website_toolbar.tpl
+++ b/packages/ezwt_extension/ezextension/ezwt/design/standard/templates/parts/website_toolbar.tpl
@@ -48,7 +48,10 @@
 {include uri='design:parts/websitetoolbar/logo.tpl'}
 
 <form method="post" action={"content/action"|ezurl}>
-
+{if is_set($redirect_uri)}
+    <input type="hidden" name="RedirectURIAfterPublish" value="{$redirect_uri|wash}" />
+    <input type="hidden" name="RedirectIfDiscarded" value="{$redirect_uri|wash}" />
+{/if}
 {if and( $content_object.can_create, $is_container )}
 <div id="ezwt-creataction" class="ezwt-actiongroup">
 <label for="ezwt-create" class="hide">Create:</label>


### PR DESCRIPTION
> See [EZP-23478](https://jira.ez.no/browse/EZP-23478)
> See ezsystems/ezdemo#38

If a `redirect_uri` template variable is provided to `parts/website_toolbar.tpl`, adds matching form fields so that redirection after publish can be controlled.
