### PR TITLE
Fix EZP-25531: Replaced 'clearContentCache()' with 'clearContentCacheIfNeeded()'

### DIFF
--- a/packages/ezwt_extension/ezextension/ezwt/classes/ezwtservercallfunctions.php
+++ b/packages/ezwt_extension/ezextension/ezwt/classes/ezwtservercallfunctions.php
@@ -56,7 +56,7 @@ class ezwtServerCallFunctions
         if ( $http->hasPostVariable( 'ContentObjectID' ) )
         {
             $objectID = $http->postVariable( 'ContentObjectID' );
-            eZContentCacheManager::clearContentCache( $objectID );
+            eZContentCacheManager::clearContentCacheIfNeeded( $objectID );
         }
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25531

`ezwtServerCallFunctions::updatePriority()` calls `eZContentCacheManager::clearContentCache()` directly on `ezpublish_legacy/extension/ezwt/classes/ezwtservercallfunctions.php`.

Therefore, if you use the toolbar and you are changing the priority, the cache will be expired - no matter if it's activated or not.