### PR TITLE
Fix EZP-29144: Website Toolbar cache doesn't work properly when Owner ( Self ) Policy Limitation is used

### DIFF
--- a/packages/ezwt_extension/ezextension/ezwt/README
+++ b/packages/ezwt_extension/ezextension/ezwt/README
@@ -11,7 +11,7 @@ Next, insert the following lines into your pagelayout.tpl file:
 
 {def $user_hash = concat( $current_user.role_id_list|implode( '_' ), '_', $current_user.limited_assignment_value_list|implode( '_' ) )}
  
-{cache-block keys=array( $uri_string, $user_hash )}
+{cache-block keys=array( $uri_string, $user_hash, $current_user.contentobject_id|eq( $pagedata.owner_id ) )}
 
     {include uri='design:parts/website_toolbar.tpl' current_node_id=$module_result.node_id}
 


### PR DESCRIPTION
JIRA issue: [EZP-29144](https://jira.ez.no/browse/EZP-29144)

Excerpt from JIRA:

> Currently, the cache related to Website Toolbar doesn't take into the account if someone is an owner of the viewed Content Object. This means that if someone who doesn't have content/edit permissions access views this Content Object first, then the owner won't have an option to edit that Content Object using Website Toolbar.

This PR fixes the issue in Legacy by introducing a new key (boolean) to the cache block that encompasses the website toolbar. The key should equal true if the logged in user is the owner of the accessed node.

Related PR: https://github.com/ezsystems/ezdemo/pull/44