### PR TITLE
EZP-29587: Avoid PHP7 deprecation errors when running legacy

### DIFF
--- a/packages/ezwt_extension/ezextension/ezwt/autoloads/ezcreateclasslistgroups.php
+++ b/packages/ezwt_extension/ezextension/ezwt/autoloads/ezcreateclasslistgroups.php
@@ -26,10 +26,6 @@
 
 class eZCreateClassListGroups
 {
-    function eZCreateClassListGroups()
-    {
-    }
-
     function operatorList()
     {
         return array( 'ezcreateclasslistgroups' );


### PR DESCRIPTION
remove Warning 
Use of deprecated PHP4 style class constructor is not supported since PHP 7.